### PR TITLE
Build args

### DIFF
--- a/0.5/Dockerfile-rhos
+++ b/0.5/Dockerfile-rhos
@@ -16,25 +16,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster-slim as builder
+#
+# This Dockerfile was modified to create a certifiable OpenShift image
+#
+FROM registry.access.redhat.com/ubi8/openjdk-8:1.3-12 as builder
 
-ARG JANUS_VERSION=0.5.3
+ARG GIT_REVISION=v0.5
+ARG JANUS_VERSION=0.5
 ARG YQ_VERSION=3.4.1
 
 ENV JANUS_VERSION=${JANUS_VERSION} \
-    JANUS_HOME=/opt/janusgraph
+    JANUS_HOME=/opt/janusgraph \
+    GIT_REVISION=${GIT_REVISION}
 
 WORKDIR /opt
 
-RUN apt update -y && apt install -y gpg unzip curl && \
-    curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}.zip -o janusgraph.zip && \
-    curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}.zip.asc -o janusgraph.zip.asc && \
-    curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/KEYS -o KEYS && \
+RUN curl -fSL https://github.com/markstur/demo-db/archive/${GIT_REVISION}.zip -o source.zip && \
     curl -fSL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -o yq && \
-    gpg --import KEYS && \
-    gpg --batch --verify janusgraph.zip.asc janusgraph.zip && \
-    unzip janusgraph.zip && \
-    mv janusgraph-${JANUS_VERSION} /opt/janusgraph && \
+    unzip source.zip && \
+    cd demo-db-* && \
+    mvn clean install -Pjanusgraph-release -Dgpg.skip=true --no-transfer-progress -Drat.skip=true -DskipTests=true && \
+    pwd && \
+    ls && \
+    mkdir -p /opt/janusgraph/licenses && \
+    cp APACHE-2.0.txt /opt/janusgraph/licenses/ && \
+    cp CC-BY-4.0.txt /opt/janusgraph/licenses/ && \
+    cp NOTICE.txt /opt/janusgraph/licenses/ && \
+    cp LICENSE.txt /opt/janusgraph/licenses/ && \
+    cd janusgraph-dist/target/ && \
+    ls && \
+    ls janusgraph-full-*.zip && \
+    unzip janusgraph-full-*.zip && \
+    mv janusgraph-full-*/* /opt/janusgraph/ && \
+    ls /opt/janusgraph && \
     rm -rf ${JANUS_HOME}/elasticsearch && \
     rm -rf ${JANUS_HOME}/javadocs && \
     rm -rf ${JANUS_HOME}/log && \
@@ -43,13 +57,19 @@ RUN apt update -y && apt install -y gpg unzip curl && \
 COPY conf/ ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM registry.access.redhat.com/ubi8/openjdk-11:1.3-15
-
-USER root
+FROM registry.access.redhat.com/ubi8/openjdk-8:1.3-12
 
 ARG CREATED=test
-ARG REVISION=test
-ARG JANUS_VERSION=0.5.3
+ARG GIT_REVISION=test
+ARG JANUS_VERSION=0.5
+
+LABEL name="DemoDB" \
+      maintainer="developer@example.com" \
+      vendor="IBM" \
+      version=${JANUS_VERSION} \
+      release="1" \
+      summary="A demo database" \
+      description="A demo database for OpenShift certification"
 
 ENV JANUS_VERSION=${JANUS_VERSION} \
     JANUS_HOME=/opt/janusgraph \
@@ -65,19 +85,35 @@ ENV JANUS_VERSION=${JANUS_VERSION} \
     gremlinserver.host=0.0.0.0 \
     gremlinserver.channelizer=org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
 
-COPY --chown=:0 --from=builder /opt/janusgraph/ /opt/janusgraph/
-COPY --chown=:0 --from=builder /opt/yq /usr/bin/yq
-COPY --chown=:0 docker-entrypoint.sh /usr/local/bin/
-COPY --chown=:0 docker-entrypoint-rhos.sh /usr/local/bin/
-COPY --chown=:0 load-initdb.sh /usr/local/bin/
+USER root
 
-RUN chmod 755 /usr/local/bin/docker-entrypoint-rhos.sh && \
+RUN groupadd -r janusgraph --gid=9999 && \
+    useradd -r -g janusgraph --uid=9999 -d ${JANUS_DATA_DIR} janusgraph && \
+    dnf -y upgrade-minimal --security --sec-severity=Important --sec-severity=Critical && \
+    rm -rf /var/lib/apt/lists/*
+
+# COPY --chown=:0 --from=builder /opt/janusgraph/ /opt/janusgraph/
+# COPY --chown=:0 --from=builder /opt/yq /usr/bin/yq
+# COPY --chown=:0 docker-entrypoint.sh /usr/local/bin/
+# COPY --chown=:0 load-initdb.sh /usr/local/bin/
+COPY --from=builder /opt/janusgraph/ /opt/janusgraph/
+COPY --from=builder /opt/yq /usr/bin/yq
+COPY docker-entrypoint.sh /usr/local/bin/
+COPY load-initdb.sh /usr/local/bin/
+
+# copy licenses
+COPY --from=builder /opt/janusgraph/licenses/ /licenses
+
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh && \
     chmod 755 /usr/local/bin/load-initdb.sh && \
     chmod 755 /usr/bin/yq && \
     mkdir -p ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR} && \
-    chgrp -R 0 ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR} && \
-    chmod -R 777 ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR} && \
-    chgrp -R 0 ${JANUS_HOME}
+    chown -R 9999:9999 ${JANUS_HOME} ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR} && \
+    chgrp -R 0 ${JANUS_HOME} ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR} && \
+    chmod -R g+w ${JANUS_HOME} ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR}
+
+RUN chmod u+x /opt/janusgraph/bin/gremlin.sh
+RUN chmod u+x /opt/janusgraph/conf/remote.yaml
 
 EXPOSE 8182
 
@@ -87,13 +123,13 @@ USER janusgraph
 ENTRYPOINT [ "docker-entrypoint-rhos.sh" ]
 CMD [ "janusgraph" ]
 
-LABEL org.opencontainers.image.title="JanusGraph Docker Image" \
-      org.opencontainers.image.description="Official JanusGraph Docker image" \
-      org.opencontainers.image.url="https://janusgraph.org/" \
-      org.opencontainers.image.documentation="https://docs.janusgraph.org/v0.5/" \
-      org.opencontainers.image.revision="${REVISION}" \
-      org.opencontainers.image.source="https://github.com/JanusGraph/janusgraph-docker/" \
-      org.opencontainers.image.vendor="JanusGraph" \
+LABEL org.opencontainers.image.title="DemoDB Docker Image" \
+      org.opencontainers.image.description="UN-Official DemoDB Docker image" \
+      org.opencontainers.image.url="https://github.com/IBM/demo-db/" \
+      org.opencontainers.image.documentation="https://github.com/IBM/demo-db/" \
+      org.opencontainers.image.revision="${GIT_REVISION}" \
+      org.opencontainers.image.source="https://github.com/IBM/demo-db" \
+      org.opencontainers.image.vendor="IBM" \
       org.opencontainers.image.version="${JANUS_VERSION}" \
       org.opencontainers.image.created="${CREATED}" \
       org.opencontainers.image.license="Apache-2.0"

--- a/0.5/Dockerfile-rhos
+++ b/0.5/Dockerfile-rhos
@@ -92,19 +92,17 @@ RUN groupadd -r janusgraph --gid=9999 && \
     dnf -y upgrade-minimal --security --sec-severity=Important --sec-severity=Critical && \
     rm -rf /var/lib/apt/lists/*
 
-# COPY --chown=:0 --from=builder /opt/janusgraph/ /opt/janusgraph/
-# COPY --chown=:0 --from=builder /opt/yq /usr/bin/yq
-# COPY --chown=:0 docker-entrypoint.sh /usr/local/bin/
-# COPY --chown=:0 load-initdb.sh /usr/local/bin/
 COPY --from=builder /opt/janusgraph/ /opt/janusgraph/
 COPY --from=builder /opt/yq /usr/bin/yq
 COPY docker-entrypoint.sh /usr/local/bin/
+COPY docker-entrypoint-rhos.sh /usr/local/bin/
 COPY load-initdb.sh /usr/local/bin/
 
 # copy licenses
 COPY --from=builder /opt/janusgraph/licenses/ /licenses
 
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh && \
+    chmod 755 /usr/local/bin/docker-entrypoint-rhos.sh && \
     chmod 755 /usr/local/bin/load-initdb.sh && \
     chmod 755 /usr/bin/yq && \
     mkdir -p ${JANUS_INITDB_DIR} ${JANUS_CONFIG_DIR} ${JANUS_DATA_DIR} && \

--- a/chart/base/templates/deployment.yaml
+++ b/chart/base/templates/deployment.yaml
@@ -41,7 +41,22 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-
+          readinessProbe:
+            tcpSocket:
+              port: 8182
+            initialDelaySeconds: 90
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 8182
+            initialDelaySeconds: 90
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           ports:
             - name: http
               containerPort: {{ .Values.image.port }}


### PR DESCRIPTION
Sync Dockerfile with the one used for operator certification and assets
Make the build download source and build instead of using pre-built files
Fix labels and use args
Add liveness/readiness probes to the deployment template